### PR TITLE
Add service-branch-date-counter tag format

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,12 @@ The action generates tags in different formats based on your needs:
 - **Without service_name**: `{date}_{branch}_{counter}`
   - Example: `2024-01-15_main_00`
 
+#### `service-branch-date-counter`
+- **With service_name**: `{service}_{branch}_{date}_{counter}`
+  - Example: `api-gateway_main_2024-01-15_00`
+- **Without service_name**: `{branch}_{date}_{counter}`
+  - Example: `main_2024-01-15_00`
+
 #### `branch-date-counter`
 - Format: `{branch}_{date}_{counter}`
 - Example: `feature-login_2024-01-15_00`
@@ -152,6 +158,15 @@ Here are examples showing exactly what tags will be generated with different inp
 **Result**: `web_2024-01-15_main_01` (counter incremented)
 
 ### Different Tag Formats
+```yaml
+# Service-Branch-Date format with counter
+- uses: koalaops/determine-image-tag@v1
+  with:
+    service_name: api
+    tag_format: service-branch-date-counter
+```
+**Result**: `api_main_2024-01-15_00`
+
 ```yaml
 # Branch-Date format with counter
 - uses: koalaops/determine-image-tag@v1

--- a/action.yml
+++ b/action.yml
@@ -18,7 +18,7 @@ inputs:
     required: false
     default: ""
   tag_format:
-    description: "Tag format: 'service-date-branch-counter' (default), 'branch-date-counter', 'branch-date', or 'date-branch'. All formats support underscore aliases (e.g., 'branch_date_counter')"
+    description: "Tag format: 'service-date-branch-counter' (default), 'service-branch-date-counter', 'branch-date-counter', 'branch-date', or 'date-branch'. All formats support underscore aliases (e.g., 'branch_date_counter')"
     required: false
     default: "service-date-branch-counter"
   max_length:
@@ -169,6 +169,13 @@ runs:
                 TAG="${DATE}_${TRUNCATED_BRANCH}"
               fi
               ;;
+            "service-branch-date-counter"|"service_branch_date_counter"|"service-branch-date"|"service_branch_date")
+              if [ -n "$TRUNCATED_SERVICE" ]; then
+                TAG="${TRUNCATED_SERVICE}_${TRUNCATED_BRANCH}_${DATE}"
+              else
+                TAG="${TRUNCATED_BRANCH}_${DATE}"
+              fi
+              ;;
             "branch-date"|"branch_date"|"branch-date-counter"|"branch_date_counter")
               TAG="${TRUNCATED_BRANCH}_${DATE}"
               ;;
@@ -177,7 +184,7 @@ runs:
               ;;
             *)
               echo "❌ Invalid TAG_FORMAT: $TAG_FORMAT"
-              echo "Valid formats: service-date-branch, branch-date, date-branch (variants: with or without counter suffix, with _ or - separator)"
+              echo "Valid formats: service-date-branch, service-branch-date, branch-date, date-branch (variants: with or without counter suffix, with _ or - separator)"
               exit 1
               ;;
           esac


### PR DESCRIPTION
## Summary

Adds support for the `service-branch-date-counter` tag format as an alternative to the default `service-date-branch-counter` format.

This new format places the branch name before the date, which can be useful for different naming conventions or sorting requirements.

**Format:**
- With service: `{service}_{branch}_{date}_{counter}`
  - Example: `api-gateway_main_2024-01-15_00`
- Without service: `{branch}_{date}_{counter}`
  - Example: `main_2024-01-15_00`

**Changes:**
- Added `service-branch-date-counter` format support in action.yml
- Supports both dash and underscore variants
- Updated documentation with format description and examples