### PR TITLE
rebrand: KoalaOps → Skyhook

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -2,7 +2,7 @@ name: Determine Image Tag
 description: |
   Generates consistent image tags for builds and releases.
   Supports multiple tag formats and handles duplicate prevention.
-author: "KoalaOps"
+author: "Skyhook"
 
 branding:
   icon: "tag"


### PR DESCRIPTION
## Summary
Update all references from KoalaOps to Skyhook as part of the rebranding initiative.

## Changes
- Organization: `KoalaOps` → `skyhook-io`
- Author: `KoalaOps` → `Skyhook`
- Product name: `Koala` → `Skyhook` (where applicable)
- All usage examples updated to reference `skyhook-io/*`
- All documentation and URLs updated

## Notes
- This PR should be merged before transferring the repository to the skyhook-io organization
- After transfer, GitHub will automatically redirect old URLs to new ones